### PR TITLE
Support mkdirp from version 0.5 as it hangs in lower versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   },
   "peerDependencies": {
-    "mkdirp": "*"
+    "mkdirp": ">=0.5.0"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "0.3.1",


### PR DESCRIPTION
mkdirp-promise specifies that any version of mkdirp can be used:

```
  "peerDependencies": {
    "mkdirp": "*"
  }
```

Unfortunately, this is not true, as it hangs in versions lower then 0.5 (if no options arg was specified)
It's a rather small fix (just set the `options` arg as an empty string if one was not specified) but I can't promise that any other issues won't rise with previous mkdirp versions.
That's why, IMO, it's best to specify a minimal version for mkdirp and avoid this issue altogether.
