### PR TITLE
mkdirp is not a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "snazzy": "^6.0.0",
     "tap": "^9.0.2"
   },
-  "peerDependencies": {
+  "dependencies": {
     "mkdirp": "*"
   }
 }


### PR DESCRIPTION
It doesn't matter if mkdirp-promise has it's own version of mkdirp installed. The user does not need to interact with mkdirp, and if they install a separate version, they won't loose functionality.

New versions of npm don't install peer dependencies automatically, so having this as a peer dependency makes it harder to use as you have to install both.