### PR TITLE
fix: lock mkdirp dependency at compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tap": "^12.0.0"
   },
   "dependencies": {
-    "mkdirp": "*",
+    "mkdirp": "^0.5.0",
     "standard": "^12.0.0"
   }
 }


### PR DESCRIPTION
Prevents this package from pulling in the breaking change 1.0.x release of `mkdirp` when it is a dependency of some other packages

Hopefully...
fixes #87 